### PR TITLE
Readme Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ poetry run pytest
 ## Usage
 
 ```python
-from perfwatch import profile_decorator
+from perfwatch import watch
 
-@profile_decorator(["line", "cpu", "time"])
+@watch(["line", "cpu", "time"])
 def test():
     for _ in range(1000000):
         pass


### PR DESCRIPTION
Readme is now updated to match the package.

**Issue**
- ImportError: cannot import name 'profile_decorator' from 'perfwatch'

**Solution**
- Using correct decorator which is "@watch" instead of profile decorator.